### PR TITLE
Add support for --webroot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 tests/test.sh
+*.swp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,14 +8,19 @@ certbot_auto_renew_extra: ""
 
 # To install from source (on older OSes or if you need a specific or newer
 # version of Certbot), set this variable to `yes` and configure other options.
-certbot_install_from_source: no
+certbot_install_method: virtualenv
 certbot_repo: https://github.com/certbot/certbot.git
 certbot_version: master
 certbot_keep_updated: yes
+# Automatically sets certbot_force_run
+certbot_expand: false
 
-# Where to put Certbot when installing from source.
+# Where to put Certbot when installing from source or pip.
 certbot_dir: /opt/certbot
 
 certbot_environment: production
 
 certbot_share_key_users: []
+
+# Set to true to run `certbot certonly` even if its config already exists
+certbot_force_run: "{{ certbot_expand }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ certbot_dir: /opt/certbot
 certbot_environment: production
 
 certbot_share_key_users: []
+certbot_share_key_dir: /etc/ssl/user
 
 # Set to true to run `certbot certonly` even if its config already exists
 certbot_force_run: "{{ certbot_expand }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Execute the certificate post-renewal script
+  command: /etc/letsencrypt/renewal-hooks/post/ansible.sh
+  when: certbot_post_renewal is defined and certbot_post_renewal

--- a/tasks/install-with-venv.yml
+++ b/tasks/install-with-venv.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure virtualenv is present
-  yum:
+  package:
     name: python-virtualenv
     state: present
 
@@ -9,15 +9,19 @@
     name:
       - certbot
       - idna<2.8,>=2.5
-    virtualenv: /opt/certbot
+    virtualenv_python: "{{ certbot_virtualenv_python | default(omit) }}"
+    virtualenv_command: "{{ certbot_virtualenv_command | default(omit) }}"
+    virtualenv: "{{ certbot_dir }}"
 
 - name: Install certbot DNS provider
   pip:
     name:
       - "certbot-{{ certbot_dns_provider }}"
-    virtualenv: /opt/certbot
+    virtualenv_python: "{{ certbot_virtualenv_python | default(omit) }}"
+    virtualenv_command: "{{ certbot_virtualenv_command | default(omit) }}"
+    virtualenv: "{{ certbot_dir }}"
   when: certbot_dns_provider is defined
 
 - name: Set Certbot script variable.
   set_fact:
-    certbot_script: "/opt/certbot/bin/certbot"
+    certbot_script: "{{ certbot_dir }}/bin/certbot"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,32 @@
 ---
-- include: include-vars.yml
+- name: Include variable setup tasks
+  import_tasks: include-vars.yml
 
-- include: install-with-venv.yml
-  #when: not certbot_install_from_source
+- name: Include virtualenv installation tasks
+  include_tasks: install-with-venv.yml
+  when: certbot_install_method == 'virtualenv'
 
-#- include: install-from-source.yml
-  #when: certbot_install_from_source
+- name: Include source installation tasks
+  include_tasks: install-from-source.yml
+  when: certbot_install_method == 'source'
 
-- include: renew-cron.yml
-  when: certbot_auto_renew
+- name: Include package installation tasks
+  include_tasks: install-from-package.yml
+  when: certbot_install_method == 'package'
 
-- include: request-cert.yml
+- name: Include cert request tasks
+  include_tasks: request-cert.yml
   when: certbot_domains
 
-- include: post-renewal.yml
-  when: certbot_post_renewal is defined
+- name: Include post-renewal script setup tasks
+  include_tasks: post-renewal.yml
+  when: certbot_post_renewal is defined and certbot_post_renewal
+
+# Force the post-renewal script to execute in case SSL webserver setup handlers run in the same play and execute before
+# our handler (handlers are run in the order their definitions are read, not in the order they are notified)
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Include cron setup tasks
+  include_tasks: renew-cron.yml
+  when: certbot_auto_renew

--- a/tasks/post-renewal.yml
+++ b/tasks/post-renewal.yml
@@ -1,19 +1,17 @@
 ---
 - name: Create the ssl-cert group if it doesn't exist
   group:
-    name: ssl-cert
+    name: "{{ certbot_ssl_group }}"
     state: present
     system: yes
+  when: certbot_ssl_group is defined
 
-- set_fact:
-    ssl_cert_group_available: true
-
-- name: Write the certificate post-renewal script
+- name: Write the certificate post-renewal hook script
   copy:
     content: |
         #!/bin/bash
         mkdir -p  /etc/ssl/private/
-        chmod 755 /etc/ssl/private/
+        chmod {{ certbot_ssl_private_dir_mode | default(750) }} /etc/ssl/private/
         chown root:ssl-cert /etc/ssl/private/
         # Chain
         cp /etc/letsencrypt/live/{{ certbot_hostname_override | default(certbot_domains[0]) }}/fullchain.pem /etc/ssl/certs/fullchain.pem
@@ -34,11 +32,7 @@
         {% endfor %}
         # Other
         {{ certbot_post_renewal }}
-
     dest: /etc/letsencrypt/renewal-hooks/post/ansible.sh
     owner: root
     group: root
     mode: "0755"
-
-- name: Execute the certificate post-renewal script
-  command: /etc/letsencrypt/renewal-hooks/post/ansible.sh

--- a/tasks/post-renewal.yml
+++ b/tasks/post-renewal.yml
@@ -12,23 +12,28 @@
         #!/bin/bash
         mkdir -p  /etc/ssl/private/
         chmod {{ certbot_ssl_private_dir_mode | default(750) }} /etc/ssl/private/
-        chown root:ssl-cert /etc/ssl/private/
-        # Chain
+        chown root:{{ certbot_ssl_group | default('') }} /etc/ssl/private/
+        # Chai
         cp /etc/letsencrypt/live/{{ certbot_hostname_override | default(certbot_domains[0]) }}/fullchain.pem /etc/ssl/certs/fullchain.pem
         chmod 644           /etc/ssl/certs/fullchain.pem
-        chown root:ssl-cert /etc/ssl/certs/fullchain.pem
+        chown root:{{ certbot_ssl_group | default('') }} /etc/ssl/certs/fullchain.pem
         # Cert
         cp /etc/letsencrypt/live/{{ certbot_hostname_override | default(certbot_domains[0]) }}/cert.pem      /etc/ssl/certs/cert.pem
         chmod 644           /etc/ssl/certs/cert.pem
-        chown root:ssl-cert /etc/ssl/certs/cert.pem
+        chown root:{{ certbot_ssl_group | default('') }} /etc/ssl/certs/cert.pem
         # Privkey
         cp /etc/letsencrypt/live/{{ certbot_hostname_override | default(certbot_domains[0]) }}/privkey.pem   /etc/ssl/private/privkey.pem
         chmod 640           /etc/ssl/private/privkey.pem
-        chown root:ssl-cert /etc/ssl/private/privkey.pem
+        chown root:{{ certbot_ssl_group | default('') }} /etc/ssl/private/privkey.pem
         # For each user, create custom version
+        {% if certbot_share_key_users %}
+        mkdir -p {{ certbot_share_key_dir }}
+        chmod 755 {{ certbot_share_key_dir }}
+        chown root:root {{ certbot_share_key_dir }}
+        {% endif %}
         {% for user in certbot_share_key_users %}
-        cp /etc/ssl/private/privkey.pem /etc/ssl/private/privkey-{{ user }}.pem
-        chown {{ user }}: /etc/ssl/private/privkey-{{ user }}.pem
+        cp /etc/ssl/private/privkey.pem {{ certbot_share_key_dir }}/privkey-{{ user }}.pem
+        chown {{ user }}: {{ certbot_share_key_dir }}/privkey-{{ user }}.pem
         {% endfor %}
         # Other
         {{ certbot_post_renewal }}

--- a/tasks/request-cert.yml
+++ b/tasks/request-cert.yml
@@ -1,19 +1,15 @@
 ---
-- name: Set Certbot script variable.
-  set_fact:
-    certbot_cmd_environment: "--test-cert"
-  when: certbot_environment == 'staging'
-
-- name: Set Certbot script variable when not staging.
-  set_fact:
-    certbot_cmd_environment: ""
-  when: certbot_environment != 'staging'
+- name: Create webroot directories
+  file:
+    path: "{{ certbot_well_known_root }}"
+    state: directory
+  when: certbot_auth_method == "--webroot"
 
 - name: Request certificate
-  command: |
+  command: >-
       {{ certbot_script }}
         certonly
-        {{ certbot_cmd_environment }}
+        {{ "--test-cert" if certbot_environment == "staging" else "" }}
         --non-interactive
         {% if certbot_dns_provider is defined %}
         --dns-{{ certbot_dns_provider }}
@@ -22,11 +18,19 @@
         {% endif %}
         -m {{ certbot_admin_email }}
         {{ certbot_agree_tos }}
+        {% if certbot_auth_method | default("--standalone") == "--webroot" %}
+        -w {{ certbot_well_known_root }}
+        {% endif %}
         -d {{ ','.join(certbot_domains) }}
+        {{ "--expand" if certbot_expand else "" }}
         {{ certbot_auto_renew_extra }}
   register: request
   args:
-    creates: "/etc/letsencrypt/renewal/{{ certbot_hostname_override | default(certbot_domains[0]) }}.conf"
+    creates: "{{ '/__not_a_real_file' if certbot_force_run else '/etc/letsencrypt/renewal/' ~ (certbot_hostname_override | default(certbot_domains[0])) ~ '.conf' }}"
+  notify:
+    - Execute the certificate post-renewal script
 
-- name: Output of command
-  debug: var=request
+- name: Log output of certbot command
+  debug:
+    var: request
+  when: request is not skipped


### PR DESCRIPTION
~~@erasche you may want to note the `certbot_ssl_private_dir_mode` var I added which defaults to `750`, but your previous value was `755`. I didn't want to default to opening up privs on the standard private key dir just in case, but wanted to make sure your setup still works. In my case I'm just adding users to the `ssl-cert` group.~~ Per-user key copies now live in `/etc/ssl/user` by default

Also general modernization and cleanup.