### PR TITLE
Add cron_file option to cron job so it can be placed in /etc/cron.d

### DIFF
--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -2,6 +2,7 @@
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
+    cron_file: "{{ certbot_auto_renew_cron_file | default(omit) }}"
     job: "{{ certbot_script }} renew --quiet --no-self-upgrade {{ certbot_auto_renew_extra }}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"


### PR DESCRIPTION
Just a trivial feature - I prefer to put my system/automated cron jobs in `/etc/cron.d` instead of user crontabs.