### PR TITLE
Add support for writing out dynamic DNS credentials

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ certbot_expand: false
 certbot_dir: /opt/certbot
 
 certbot_letsencrypt_dir: /etc/letsencrypt
+certbot_dns_credentials_file: "{{ certbot_letsencrypt_dir }}/dns-{{ certbot_dns_provider }}-credentials.ini"
 
 certbot_environment: production
 

--- a/tasks/install-with-venv.yml
+++ b/tasks/install-with-venv.yml
@@ -15,7 +15,7 @@
 - name: Install certbot DNS provider
   pip:
     name:
-      - "certbot-{{ certbot_dns_provider }}"
+      - "certbot-dns-{{ certbot_dns_provider }}"
     virtualenv_command: "{{ certbot_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
     virtualenv: "{{ certbot_dir }}"
   when: certbot_dns_provider is defined

--- a/tasks/request-cert.yml
+++ b/tasks/request-cert.yml
@@ -5,6 +5,28 @@
     state: directory
   when: certbot_auth_method == "--webroot"
 
+- name: DNS provider credential task block
+  block:
+
+    - name: Create DNS provider credential directory
+      file:
+        path: "{{ certbot_dns_credentials_file | dirname }}"
+        state: directory
+
+    - name: Create DNS provider credentials
+      copy:
+        content: |
+          ##
+          ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN.
+          ##
+          {% for item in certbot_dns_credentials | dict2items %}
+          dns_{{ certbot_dns_provider }}_{{ item.key }} = {{ item.value }}
+          {% endfor %}
+        dest: "{{ certbot_dns_credentials_file }}"
+        mode: "0400"
+
+  when: certbot_dns_provider is defined and certbot_dns_credentials is defined
+
 - name: Request certificate
   command: >-
       {{ certbot_script }}
@@ -13,6 +35,9 @@
         --non-interactive
         {% if certbot_dns_provider is defined %}
             --dns-{{ certbot_dns_provider }}
+            {% if certbot_dns_credentials is defined %}
+            --dns-{{ certbot_dns_provider }}-credentials {{ certbot_dns_credentials_file }}
+            {% endif %}
         {% else %}
             {{ certbot_auth_method | default("--standalone") }}
         {% endif %}


### PR DESCRIPTION
This makes it possible to use dns-rfc2136 (e.g. for BIND).