### PR TITLE
Fix error when certbot_dns_provider is not defined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,9 @@ certbot_expand: false
 certbot_dir: /opt/certbot
 
 certbot_letsencrypt_dir: /etc/letsencrypt
-certbot_dns_credentials_file: "{{ certbot_letsencrypt_dir }}/dns-{{ certbot_dns_provider }}-credentials.ini"
+# the test in tasks/request-cert.yml ensure that this is not used if certbot_dns_provider is not defined
+# but a default is necessary to ensure that an error is not triggered when certbot_dns_provider is not defined 
+certbot_dns_credentials_file: "{{ certbot_letsencrypt_dir }}/dns-{{ certbot_dns_provider | default('ERROR') }}-credentials.ini"
 
 certbot_environment: production
 


### PR DESCRIPTION
If the `certbot_dns_provider` is not defined the `certbot_dns_credentials_file` variable is not used. Its reference to `certbot_dns_provider`, however, causes an error when that variable is not defined. This PR adds a (invalid) default to silence that error.