### PR TITLE
Make dns plugin package name configurable + fix authenticator option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ certbot_auto_renew_extra: ""
 # version of Certbot), set this variable to `yes` and configure other options.
 certbot_install_method: virtualenv
 certbot_package: certbot
+certbot_dns_plugin_package: "certbot-dns-{{ certbot_dns_provider }}"
 certbot_script: "{{ certbot_package }}"
 certbot_repo: https://github.com/certbot/certbot.git
 certbot_version: master
@@ -22,7 +23,7 @@ certbot_dir: /opt/certbot
 
 certbot_letsencrypt_dir: /etc/letsencrypt
 # the test in tasks/request-cert.yml ensure that this is not used if certbot_dns_provider is not defined
-# but a default is necessary to ensure that an error is not triggered when certbot_dns_provider is not defined 
+# but a default is necessary to ensure that an error is not triggered when certbot_dns_provider is not defined
 certbot_dns_credentials_file: "{{ certbot_letsencrypt_dir }}/dns-{{ certbot_dns_provider | default('ERROR') }}-credentials.ini"
 
 certbot_environment: production

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -29,6 +29,6 @@
 
 - name: Install Certbot DNS package
   package:
-    name: "certbot-dns-{{ certbot_dns_provider }}"
+    name: "{{ certbot_dns_plugin_package }}"
     state: present
   when: certbot_dns_provider is defined

--- a/tasks/install-with-venv.yml
+++ b/tasks/install-with-venv.yml
@@ -15,7 +15,7 @@
 - name: Install certbot DNS provider
   pip:
     name:
-      - "certbot-dns-{{ certbot_dns_provider }}"
+      - "{{ certbot_dns_plugin_package }}"
     virtualenv_command: "{{ certbot_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
     virtualenv: "{{ certbot_dir }}"
   when: certbot_dns_provider is defined

--- a/tasks/request-cert.yml
+++ b/tasks/request-cert.yml
@@ -34,7 +34,7 @@
         {{ "--test-cert" if certbot_environment == "staging" else "" }}
         --non-interactive
         {% if certbot_dns_provider is defined %}
-            --dns-{{ certbot_dns_provider }}
+            --authenticator dns-{{ certbot_dns_provider }}
             {% if certbot_dns_credentials is defined %}
             --dns-{{ certbot_dns_provider }}-credentials {{ certbot_dns_credentials_file }}
             {% endif %}


### PR DESCRIPTION
2 small changes I had to do to use it on genouest server:
- the gandi dns plugin provider uses a specific package name (`certbot-plugin-gandi`), so added the `certbot_dns_plugin_package` variable to be able to customize it
- also fixed the --dns-xx/--authenticator option, I guess it changed recently in certbot