### PR TITLE
Drop deprecated `--no-self-upgrade` option to renew

### DIFF
--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -3,7 +3,7 @@
   ansible.builtin.cron:
     name: Certbot automatic renewal.
     cron_file: "{{ certbot_auto_renew_cron_file | default(omit) }}"
-    job: "{{ certbot_script }} renew --quiet --no-self-upgrade {{ certbot_auto_renew_extra }}"
+    job: "{{ certbot_script }} renew --quiet {{ certbot_auto_renew_extra }}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"


### PR DESCRIPTION
This option has long been deprecated and running with this outputs a warning:

```
Use of --no-self-upgrade is deprecated.
```

I'm not 100% certain that this is "deprecated and removed" vs. "deprecated but still works" but I can't find anything indicating that certbot still has automatic upgrade support (and in fact, the only thing I can find suggesting that it ever did have it was in the long-defunct `certbot-auto` script, not certbot itself).