### PR TITLE
No log in copy dns credentials task

### DIFF
--- a/tasks/request-cert.yml
+++ b/tasks/request-cert.yml
@@ -27,6 +27,7 @@
           {% endfor %}
         dest: "{{ certbot_dns_credentials_file }}"
         mode: "0400"
+      no_log: true
 
 - name: Request certificate
   ansible.builtin.command: >-


### PR DESCRIPTION
I think the credentials would be shown in logs with `--diff` option, otherwise